### PR TITLE
[DNM] NetworkSwitcher: Rework the checking of default modem

### DIFF
--- a/hardware/NetworkSwitcher/src/com/yoshino/networkswitcher/NetworkSwitcher.kt
+++ b/hardware/NetworkSwitcher/src/com/yoshino/networkswitcher/NetworkSwitcher.kt
@@ -439,6 +439,7 @@ class NetworkSwitcher : Service() {
 
     /**
      * @return if modem flashed is one of the [DEFAULT_MODEMS]
+     * or whether modem name contains one of `ims`, `volte`, `vilte` or `vowifi`
      */
     private fun isModemDefault(): Boolean {
         val modemConfig = readModemFile()
@@ -446,7 +447,8 @@ class NetworkSwitcher : Service() {
             for (m in DEFAULT_MODEMS) {
                 if (modemConfig[1] == m) return true
             }
-            false
+            !modemConfig[1].contains("ims") && !modemConfig[1].contains("volte")
+                    && !modemConfig[1].contains("vilte") && !modemConfig[1].contains("vowifi")
         } else true
     }
 
@@ -459,10 +461,12 @@ class NetworkSwitcher : Service() {
         return try {
             val file = File(MODEM_SWITCHER_STATUS)
             if (file.exists()) {
-                val br = BufferedReader(FileReader(file))
-                val line = br.readLine().replace("\n", "").replace("\r", "").trim()
-                br.close()
-                arrayOf(line.split(",".toRegex())[0], line.split(",".toRegex())[1])
+                var line = ""
+                BufferedReader(FileReader(file)).use { br -> br.forEachLine { line += it } }
+                line = line.replace("\n", "").replace("\r", "")
+                        .replace("{", "").replace("}", "").replace("\"", "").trim()
+
+                if (line == "") null else arrayOf(line.split(",".toRegex())[0], line.split(",".toRegex())[1])
             } else {
                 null
             }

--- a/hardware/NetworkSwitcher/src/com/yoshino/networkswitcher/NotificationHelper.kt
+++ b/hardware/NetworkSwitcher/src/com/yoshino/networkswitcher/NotificationHelper.kt
@@ -68,7 +68,7 @@ class NotificationHelper(private val context: Context) {
             .setColorized(true).build()
 
     private fun getModemNotification(modemConfig: String, status: String, registration: String): Notification {
-        val finalStatus = if (status == "0") "Success ($status)" else "Failed ($status)"
+        val finalStatus = if (status.contains("0")) "Success (0)" else "Failed ($status)"
         return NotificationCompat.Builder(context, CHANNEL_ID)
                 .setContentTitle(CHANNEL_ID)
                 .setContentText("Status: $finalStatus\nConfig: $modemConfig\nIMS: $registration")


### PR DESCRIPTION
Other than the known list of default modems, some 'non-default' modems don't support IMS

Now, it will return modem is default IF, the modem config in `modem_switcher_status` is one of the default modems OR modem config file name does not contain one of `ims`, `volte`, `vilte` or `vowifi` regex


#### Testing is required first :)