### PR TITLE
yoshino-common: Add poplar_nonfc

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -17,7 +17,7 @@
 LOCAL_PATH := $(call my-dir)
 
 ifneq ($(filter yoshino,$(PRODUCT_PLATFORM)),)
-ifneq ($(filter lilac poplar poplar_canada poplar_dsds maple maple_dsds, $(TARGET_DEVICE)),)
+ifneq ($(filter lilac poplar poplar_canada poplar_nonfc poplar_dsds maple maple_dsds, $(TARGET_DEVICE)),)
 include $(call all-subdir-makefiles,$(LOCAL_PATH))
 endif
 endif

--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -43,6 +43,10 @@ static inline const char* getBTDefaultName()
     if (!strcmp("poplar_canada", device)) {
         return "Xperia XZ1";
     }
+    
+    if (!strcmp("poplar_nonfc", device)) {
+        return "Xperia XZ1";
+    }
 
     if (!strcmp("poplar_dsds", device)) {
         return "Xperia XZ1 Dual";

--- a/config/Android.mk
+++ b/config/Android.mk
@@ -16,6 +16,6 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter lilac poplar poplar_canada poplar_dsds maple maple_dsds, $(TARGET_DEVICE)),)
+ifneq ($(filter lilac poplar poplar_canada poplar_nonfc poplar_dsds maple maple_dsds, $(TARGET_DEVICE)),)
 include $(call all-subdir-makefiles,$(LOCAL_PATH))
 endif


### PR DESCRIPTION
 * poplar_nonfc is a variant of poplar device tree with NFC disabled in its device tree
   by disabling kernel module execution

 * We need this because many of XZ1 users have SOV36 Japanese variant instead of G8341,
   that has a different NFC chip and would just need a different kernel driver, but
   thanks to @ itsbytebites we discovered that our phones are missing the entire NFC
   antenna. It was removed from a chinese seller that claims to ship G8341 devices.

 * Having NFC kernel module loaded makes the device to not enter deep sleep mode, as well
   as log spam with errors regarding it