### PR TITLE
yoshino-common: sepolicy: Fix policy for clean_scratch_files

### DIFF
--- a/sepolicy/vendor/clean_scratch_files.te
+++ b/sepolicy/vendor/clean_scratch_files.te
@@ -1,6 +1,8 @@
 # clean_scratch_files.te
 
 type clean_scratch_files, domain;
-type clean_scratch_files_exec, exec_type, file_type;
+type clean_scratch_files_exec, exec_type, file_type, system_file_type;
+
+typeattribute clean_scratch_files coredomain;
 
 init_daemon_domain(clean_scratch_files)


### PR DESCRIPTION
This fixes neverallows for both maple (non-treble) and lilac/poplar (treble).