### PR TITLE
OpenCS fix for maple

### DIFF
--- a/hardware/OpenCustomizationSelector/AndroidManifest.xml
+++ b/hardware/OpenCustomizationSelector/AndroidManifest.xml
@@ -91,6 +91,9 @@
         <service
             android:name="com.sonymobile.customizationselector.NS.NetworkSwitcher"
             android:enabled="true" />
+        <service
+            android:name="com.sonymobile.customizationselector.MapleStarter"
+            android:enabled="true" />
 
         <receiver android:name="com.sonymobile.customizationselector.EventReceiver">
             <intent-filter android:priority="999">

--- a/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/MapleStarter.java
+++ b/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/MapleStarter.java
@@ -3,10 +3,13 @@ package com.sonymobile.customizationselector;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.app.Service;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.graphics.Color;
+import android.os.IBinder;
 import android.os.SystemProperties;
 import android.provider.Settings;
 import android.telephony.SubscriptionManager;
@@ -16,65 +19,69 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 
-public class EventReceiver extends BroadcastReceiver {
+public class MapleStarter extends Service {
 
-    private static final String TAG = EventReceiver.class.getSimpleName();
+    private static final String TAG = "MapleStarter";
     private static final String CHANNEL_ID = "Sony Modem";
 
-    private int getSubId(Context context, Intent intent) {
-        int intExtra = intent.getIntExtra("subscription", SubscriptionManager.INVALID_SUBSCRIPTION_ID);
-        CSLog.d(TAG, "Event received for subscription: " + intExtra);
-        return (intExtra == -1 || !CommonUtil.isMandatorySimParamsAvailable(context, intExtra)) ? -1 : intExtra;
+    public static boolean mStarted = false;
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
     }
 
-    public void onReceive(Context context, Intent intent) {
-        if (context == null || intent == null) {
-            CSLog.d(TAG, "Context or Intent was null.");
-            return;
-        }
+    private int mSubID = -1;
 
-        String buildFlavor = SystemProperties.get("ro.build.flavor", "--");
-        if (buildFlavor.contains("maple")) {
-            CSLog.d(TAG, "DEVICE IS MAPLE !");
-            if (!MapleStarter.mStarted) {
-                MapleStarter.mStarted = true;
-                context.startService(new Intent(context, MapleStarter.class));
-            }
-            return;
-        }
-
-        if (Settings.System.getInt(context.getContentResolver(), "cs_ims", 0) == 0) {
-            CSLog.d(TAG, "IMS disabled, not parsing");
-            int subID = getSubId(context, intent);
-            if (subID != -1) {
-                CSLog.d(TAG, "Saving sub ID for later");
-                context.createDeviceProtectedStorageContext().getSharedPreferences(Configurator.PREF_PKG, Context.MODE_PRIVATE)
-                        .edit().putInt("event_subID", getSubId(context, intent)).apply();
-            }
-            if (!CommonUtil.isModemDefault(readModemFile()[1])) {
-                CSLog.d(TAG, "Modem not default but IMS turned off as per settings.");
-                new ImsSwitcher(context).switchOffIMS();
-            }
-            return;
-        }
-
-        String action = intent.getAction();
-        if ("android.telephony.action.CARRIER_CONFIG_CHANGED".equals(action)) {
+    private final BroadcastReceiver carrierConfigReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
             CSLog.d(TAG, "Carrier config changed received");
+            mSubID = getSubId(context, intent);
+        }
+    };
 
-            if (CommonUtil.isDefaultDataSlot(context, getSubId(context, intent))) {
+    private final BroadcastReceiver bootReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            CSLog.d(TAG, "BOOT COMPLETE changed received");
+
+            if (CommonUtil.isDefaultDataSlot(context, mSubID)) {
                 CSLog.d(TAG, "Default data SIM loaded");
                 Intent service = new Intent(context, CustomizationSelectorService.class);
                 service.setAction("evaluate_action");
                 context.startService(service);
             }
-        } else if ("android.intent.action.BOOT_COMPLETED".equals(action)) {
             if (CommonUtil.isDualSim(context)) {
                 DSDataSubContentJob.scheduleJob(context);
             }
-
             notifyStatus(context);
+            mStarted = false;
+
+            unregisterReceiver(bootReceiver);
+            unregisterReceiver(carrierConfigReceiver);
+            CSLog.d(TAG, "Stopping...");
+            stopSelf();
         }
+    };
+
+    @Override
+    public void onCreate() {
+        CSLog.d(TAG, "Service: onCreate");
+        registerReceiver(carrierConfigReceiver, new IntentFilter("android.telephony.action.CARRIER_CONFIG_CHANGED"));
+        registerReceiver(bootReceiver, new IntentFilter(Intent.ACTION_BOOT_COMPLETED));
+        super.onCreate();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return START_STICKY;
+    }
+
+    private int getSubId(Context context, Intent intent) {
+        int intExtra = intent.getIntExtra("subscription", SubscriptionManager.INVALID_SUBSCRIPTION_ID);
+        CSLog.d(TAG, "Event received for subscription: " + intExtra);
+        return (intExtra == -1 || !CommonUtil.isMandatorySimParamsAvailable(context, intExtra)) ? -1 : intExtra;
     }
 
     private void notifyStatus(Context context) {


### PR DESCRIPTION
Since maple is FDE, the `/data` isn't accessible until unlocked at boot.
Hence, start a service if device is maple and collect subscription ID then trigger init process when `BOOT_COMPLETED`.