### PR TITLE
overlay: location: Whitelist UnifiedNLP as location provider

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -57,26 +57,6 @@
         <item>"mobile_emergency,15,0,5,-1,true"</item>
     </string-array>
 
-    <!-- Package name(s) containing location provider support.
-         These packages can contain services implementing location providers,
-         such as the Geocode Provider, Network Location Provider, and
-         Fused Location Provider. They will each be searched for
-         service components implementing these providers.
-         It is strongly recommended that the packages explicitly named
-         below are on the system image, so that they will not map to
-         a 3rd party application.
-         The location framework also has support for installation
-         of new location providers at run-time. The new package does not
-         have to be explicitly listed here, however it must have a signature
-         that matches the signature of at least one package on this list.
-         -->
-    <string-array name="config_locationProviderPackageNames" translatable="false">
-        <!-- The standard AOSP fused location provider -->
-        <item>com.android.location.fused</item>
-        <!-- The Google provider -->
-        <item>com.google.android.gms</item>
-    </string-array>
-
     <!-- This string array should be overridden by the device to present a list of radio
          attributes.  This is used by the connectivity manager to decide which networks can coexist
          based on the hardware -->


### PR DESCRIPTION
Copy the ``config_locationProviderPackageNames`` from base lineageOS to whitelist ``org.microg.nlp``, as per  https://review.lineageos.org/c/LineageOS/android_vendor_lineage/+/305449

With this, and installing UnifiedNLP in ``/system/priv-app``, seems to result in a working UnifiedNLP (at least, as far as I know to test it, I get full ticks on it's self-check and seen OSMAnd+ use a cell-tower approximate location).

This said, the better solution here may well be to remove this config block entirely and use the LineageOS defaults (I think that's what it'd do? I'm still feeling my way round building Android) since with this they're the same (assuming the comment is right and order doesn't matter). Looks like at one point it was useful to enable the qualcomm location provider, but that was removed in https://github.com/whatawurst/android_device_sony_yoshino-common/commit/9719dd4909f177ac7ed063c3b2069f4a095b00e0.