### PR TITLE
libqti-perfd-client: Fix function signatures and return values

### DIFF
--- a/hardware/libqti-perfd-client/client.cpp
+++ b/hardware/libqti-perfd-client/client.cpp
@@ -1,10 +1,20 @@
 #include <stdint.h>
 
-namespace android {
-    extern "C" void perf_get_feedback() {}
-    extern "C" void perf_hint() {}
-    extern "C" void perf_lock_acq() {}
-    extern "C" void perf_lock_cmd() {}
-    extern "C" void perf_lock_rel() {}
-    extern "C" void perf_lock_use_profile() {}
+extern "C" {
+    void perf_get_feedback() {}
+    int perf_hint(int /*hint*/, const char* /*pkg*/, int /*duration*/, int /*type*/) {
+        return 233;
+    }
+    int perf_lock_acq(int handle, int /*duration*/, int* /*hints*/, int /*num_args*/) {
+        if (handle > 0)
+            return handle;
+        return 233;
+    }
+    void perf_lock_cmd() {}
+    int perf_lock_rel(int handle) {
+        if (handle > 0)
+            return handle;
+        return 233;
+    }
+    void perf_lock_use_profile() {}
 }


### PR DESCRIPTION
- Use correct function signatures
- Remove namespace (not required due to extern "C"
- Put extern C into scope
- Return non-negative dummy values so callers don't see this as failed

Idea from: https://review.lineageos.org/c/LineageOS/android_device_xiaomi_sdm845-common/+/310583

Note: I'm quite sure the release part is wrong. It rather looks like an error code which should be returned, not the handle. The only place I could find this to be used checks against "-1". But can't tell for sure.

Closes https://github.com/whatawurst/android_device_sony_lilac/issues/33