### PR TITLE
Fix SELinux permission of netmgrd

### DIFF
--- a/BoardConfigPlatform.mk
+++ b/BoardConfigPlatform.mk
@@ -146,6 +146,10 @@ include device/qcom/sepolicy-legacy-um/SEPolicy.mk
 BOARD_VENDOR_SEPOLICY_DIRS += device/sony/yoshino-common/sepolicy/vendor
 BOARD_PLAT_PRIVATE_SEPOLICY_DIR += device/sony/yoshino-common/sepolicy/private
 
+### TREBLE
+# Enable treble
+PRODUCT_FULL_TREBLE_OVERRIDE ?= true
+
 ### VENDOR FILE OVERRIDE
 BUILD_BROKEN_DUP_RULES := true
 

--- a/sepolicy/vendor/netmgrd.te
+++ b/sepolicy/vendor/netmgrd.te
@@ -1,0 +1,10 @@
+# netmgrd.te
+
+typeattribute netmgrd vendor_executes_system_violators;
+
+# Allow execution of commands in shell
+allow netmgrd system_file:file x_file_perms;
+
+# Read those files
+allow netmgrd system_file:file { open read };
+


### PR DESCRIPTION
Allow netmgrd to execute system commands

E.g. the lilac one accesses the following commands
- /system/bin/linker64
- /system/bin/ip addr flush dev %s
- /system/bin/ip-wrapper-1.0 -6 addr flush dev %s scope global

See for similar allows, especially the one from Sony: https://github.com/sonyxperiadev/device-qcom-sepolicy/blob/4fa99c11e926b3e5f8cd829e8e2022e72a605131/common/netmgrd.te#L50-L51 https://github.com/LineageOS/android_device_samsung_msm8930-common/blob/1ba8e965e7b4e343b6de8cf7a2c73715d123d557/sepolicy/netmgrd.te#L23-L24 https://github.com/JAOSP/aosp_device_htc_flounder/blob/ba666eb415ce5818beb0b2c4ccbda77a9b8cb272/sepolicy/netmgrd.te#L26-L27

Note: Actual failures observed on lilac. audit2allow only shows "exec" as the required fix, but still used the macro used by Sony

Might be the cause for the phone not getting any connection after being offline for a while (e.g. in an area without any reception)