### PR TITLE
DNM: OpenCS, XperiaParts: Enable IMS by default

### DIFF
--- a/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/EventReceiver.java
+++ b/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/EventReceiver.java
@@ -33,14 +33,15 @@ public class EventReceiver extends BroadcastReceiver {
             return;
         }
 
-        if (Settings.System.getInt(context.getContentResolver(), "cs_ims", 0) == 0) {
+        int subID = getSubId(context, intent);
+        if (subID != -1) {
+            CSLog.d(TAG, "Saving sub ID for later");
+            context.createDeviceProtectedStorageContext().getSharedPreferences(Configurator.PREF_PKG, Context.MODE_PRIVATE)
+                    .edit().putInt("event_subID", getSubId(context, intent)).apply();
+        }
+
+        if (Settings.System.getInt(context.getContentResolver(), "cs_ims", 1) == 0) {
             CSLog.d(TAG, "IMS disabled, not parsing");
-            int subID = getSubId(context, intent);
-            if (subID != -1) {
-                CSLog.d(TAG, "Saving sub ID for later");
-                context.createDeviceProtectedStorageContext().getSharedPreferences(Configurator.PREF_PKG, Context.MODE_PRIVATE)
-                        .edit().putInt("event_subID", getSubId(context, intent)).apply();
-            }
             if (!CommonUtil.isModemDefault(readModemFile()[1])) {
                 CSLog.d(TAG, "Modem not default but IMS turned off as per settings.");
                 new ImsSwitcher(context).switchOffIMS();

--- a/hardware/XperiaParts/res/xml/device_settings.xml
+++ b/hardware/XperiaParts/res/xml/device_settings.xml
@@ -44,7 +44,7 @@
             android:title="@string/status" />
 
         <SwitchPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:icon="@drawable/ic_outline_wifi_calling_24"
             android:key="cs_ims"
             android:summary="@string/ims_summary"

--- a/hardware/XperiaParts/src/com/yoshino/parts/DeviceSettingsFragment.java
+++ b/hardware/XperiaParts/src/com/yoshino/parts/DeviceSettingsFragment.java
@@ -118,7 +118,7 @@ public class DeviceSettingsFragment extends PreferenceFragment implements Prefer
 
         SwitchPreference imsPref = findPreference(CS_IMS);
         assert imsPref != null;
-        if (Settings.System.getInt(imsPref.getContext().getContentResolver(), CS_IMS, 0) == 0) {
+        if (Settings.System.getInt(imsPref.getContext().getContentResolver(), CS_IMS, 1) == 0) {
             imsPref.setChecked(false);
             notificationPref.setEnabled(false);
             msActPref.setEnabled(false);
@@ -128,7 +128,7 @@ public class DeviceSettingsFragment extends PreferenceFragment implements Prefer
             msActPref.setEnabled(true);
         }
         imsPref.setOnPreferenceClickListener(preference -> {
-            int ims = Settings.System.getInt(imsPref.getContext().getContentResolver(), CS_IMS, 0);
+            int ims = Settings.System.getInt(imsPref.getContext().getContentResolver(), CS_IMS, 1);
             if (ims == 1) {
                 AlertDialog.Builder builder = new AlertDialog.Builder(imsPref.getContext());
                 builder.setCancelable(false);
@@ -199,7 +199,7 @@ public class DeviceSettingsFragment extends PreferenceFragment implements Prefer
 
     private void sendBroadcast(Context context) {
         Intent broadcast = new Intent()
-                .putExtra(CS_IMS, Settings.System.getInt(context.getContentResolver(), CS_IMS, 0))
+                .putExtra(CS_IMS, Settings.System.getInt(context.getContentResolver(), CS_IMS, 1))
                 .addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
                 .setComponent(new ComponentName("com.sonymobile.customizationselector",
                         "com.sonymobile.customizationselector.PreferenceReceiver"));


### PR DESCRIPTION
IMS will now by enabled by default. However, it won't reflect on dirty flash as the preference would be already stored in
```java
Settings.System.getInt(context.getContentResolver(), /* pref key */ "cs_ims", /* default value */);
```
where `/* default value */` was `0` previously.

PS: If some user haven't toggled IMS preference from Xperia Parts even once yet, then IMS will be enabled by default as mentioned above.

**Please test and verify before merge :)**