### PR TITLE
Revert "yoshino-common: Disable use_buffer_age to workaround driver i…

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -66,9 +66,6 @@ debug.gralloc.enable_fb_ubwc=1
 vendor.display.disable_scaler=1
 vendor.display.perf_hint_window=50
 
-# HWUI
-debug.hwui.use_buffer_age=false
-
 # Display default color mode enable
 vendor.display.enable_default_color_mode=1
 


### PR DESCRIPTION
…ssue"

Ever since the T QPR1 merge, this prop causes (semi-)random janks.

Since our device shouldn't be old enough to require it anyway, just drop the prop.

This reverts commit 64db08e8db7ebd3d820c3f08920a8a5d82998d6e.