### PR TITLE
OpenCS: Fix notification intent

### DIFF
--- a/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/EventReceiver.java
+++ b/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/EventReceiver.java
@@ -87,7 +87,7 @@ public class EventReceiver extends BroadcastReceiver {
                                     "\nCust ID: " + SystemProperties.get(Configurator.PROP_TA_AC_VERSION, "N/A")))
                     .setColorized(true)
                     .addAction(R.drawable.ic_baseline_sim_card_24, "Disable Notification",
-                            PendingIntent.getBroadcast(context, 1, new Intent(context, NotificationReceiver.class), PendingIntent.FLAG_MUTABLE))
+                            PendingIntent.getBroadcast(context, 1, new Intent(context, NotificationReceiver.class), PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE))
                     .build());
         }
     }


### PR DESCRIPTION
Readd `FLAG_UPDATE_CURRENT`

This was (IMO erroneously) removed in https://github.com/whatawurst/android_device_sony_yoshino-common/commit/27e84e34dfb04fa2045b557e0416bf5d1c78df1d

@shank03 Can you verify?