### PR TITLE
sepolicy: debugfs guarded and disabled on user builds

### DIFF
--- a/sepolicy/vendor/kernel.te
+++ b/sepolicy/vendor/kernel.te
@@ -4,4 +4,8 @@
 allow kernel proc_cmdline:file r_file_perms;
 
 # /sys/kernel/debug/ipc_logging
-allow kernel qti_debugfs:dir r_dir_perms;
+no_debugfs_restriction(`
+  userdebug_or_eng(`
+    allow kernel qti_debugfs:dir r_dir_perms;
+  ')
+')


### PR DESCRIPTION
Following
https://github.com/LineageOS/android_device_qcom_sepolicy/commit/fc9b1c61053b68a720f4eb6c3142c3b2ed0eaba5, debugfs is now guarded by PRODUCT_SET_DEBUGFS_RESTRICTIONS and disabled on user builds.